### PR TITLE
Error running render.py due to unknown params

### DIFF
--- a/scene/__init__.py
+++ b/scene/__init__.py
@@ -81,8 +81,19 @@ class Scene:
                                                            "iteration_" + str(self.loaded_iter),
                                                            "point_cloud.ply"))
             self.gaussians._vdgs = load(os.path.join(self.model_path, "point_cloud", "iteration_" + str(self.loaded_iter), "mlp_model.pt"))
+            with open(os.path.join(self.model_path, "vdgs_settings.json"), 'r') as file:
+                vdgs_settings = json.load(file)
+                self.gaussians.vdgs_type = vdgs_settings["vdgs_type"]
+                self.gaussians.vdgs_operator = vdgs_settings["vdgs_operator"]
         else:
             self.gaussians.create_from_pcd(scene_info.point_cloud, self.cameras_extent)
+
+            vdgs_settings = {
+                "vdgs_type": self.gaussians.vdgs_type,
+                "vdgs_operator": self.gaussians.vdgs_operator
+            }
+            with open(os.path.join(self.model_path, "vdgs_settings.json"), 'w') as file:
+                json.dump(vdgs_settings, file)
 
     def save(self, iteration):
         point_cloud_path = os.path.join(self.model_path, "point_cloud/iteration_{}".format(iteration))


### PR DESCRIPTION
First of all thanks for your great work!

The render.py script fails for me as vdgs_type and vdgs_parameter are None within gaussian_render. For training we pass those parameters as args, but those args can't be used for the render function, also they are never saved and loaded therefor unknown for the rendering script. I build a small functionality within the scene to save and load those params for subsequent scripts (also probably good to know which configuration you used for a specific run). This is a fast implementation which is saved every saving iteration, ideally this only needs to be saved once and probably at the beginning of training. 